### PR TITLE
Fixed cstring header include issue

### DIFF
--- a/include/SimpleUtf/UtfCommon.hpp
+++ b/include/SimpleUtf/UtfCommon.hpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <cstdint>
+#include <cstring>
 
 #include <iterator>
 #include <limits>
@@ -181,6 +182,8 @@ inline
 SIMPLEUTF_BITOPS_CONSTEXPR
 size_t BitWidthChar<char32_t>(const char32_t& x) noexcept
 {
+	static_assert(!IsSigned<char32_t>::value,
+		"char32_t must be an unsigned type");
 	return BitWidth(static_cast<uint32_t>(x));
 }
 

--- a/test/src/TestUtf.cpp
+++ b/test/src/TestUtf.cpp
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include <cstring>
-
 #include <gtest/gtest.h>
 
 #include <SimpleUtf/Utf.hpp>


### PR DESCRIPTION
- Fixed cstring header include issue
  - removed `#include<cstring>` from the test code
  - instead, added `#include<cstring>` to the UtfCommon.hpp